### PR TITLE
Grant prooph user access to proophessor-do vhost

### DIFF
--- a/rabbitmq/config/wrapper-entrypoint.sh
+++ b/rabbitmq/config/wrapper-entrypoint.sh
@@ -10,7 +10,8 @@ set -e
 
     rabbitmqctl add_vhost "proophessor-do" && \
     rabbitmqctl add_user "proophessor-do" "proophessor-do" && \
-    rabbitmqctl set_permissions -p "proophessor-do" "proophessor-do"  ".*" ".*" ".*"
+    rabbitmqctl set_permissions -p "proophessor-do" "proophessor-do"  ".*" ".*" ".*" && \
+    rabbitmqctl set_permissions -p "proophessor-do" "prooph"  ".*" ".*" ".*"
 ) &
 
 # original entrypoint


### PR DESCRIPTION
Admin user `prooph` is not allowed to access vhost proophessor-do which makes working with the rabbit mgmt UI less useful. This PR solves the problem.