### PR TITLE
Working xdebug for mac users

### DIFF
--- a/php/5.6-cli-xdebug
+++ b/php/5.6-cli-xdebug
@@ -1,5 +1,7 @@
 FROM prooph/php:5.6-cli
 
+ENV XDEBUG_HOST=172.17.0.1
+
 # XDEBUG
 RUN pecl install xdebug
 

--- a/php/7.0-cli-xdebug
+++ b/php/7.0-cli-xdebug
@@ -1,5 +1,7 @@
 FROM prooph/php:7.0-cli
 
+ENV XDEBUG_HOST=172.17.0.1
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
     autoconf \

--- a/php/7.1-cli-xdebug
+++ b/php/7.1-cli-xdebug
@@ -1,6 +1,7 @@
 FROM prooph/php:7.1-cli
 
 ENV PHP_XDEBUG_VERSION master
+ENV XDEBUG_HOST=172.17.0.1
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \

--- a/php/7.2-cli-xdebug
+++ b/php/7.2-cli-xdebug
@@ -1,6 +1,7 @@
 FROM prooph/php:7.2-cli
 
 ENV PHP_XDEBUG_VERSION master
+ENV XDEBUG_HOST=172.17.0.1
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \

--- a/php/README.md
+++ b/php/README.md
@@ -47,6 +47,12 @@ Run the following command with the path to your php file.
 $ docker run --rm -it --volume $(pwd):/app -e PHP_IDE_CONFIG="serverName=application" prooph/php:7.0-cli-xdebug php [your file]
 ```
 
+Mac users doesn't have `docker0` network. According to [networking features](https://docs.docker.com/docker-for-mac/networking/#known-limitations-use-cases-and-workarounds) they should change hostname.
+
+```bash
+$ docker run --rm -it --volume $(pwd):/app -e PHP_IDE_CONFIG="serverName=application" -e XDEBUG_HOST="docker.for.mac.localhost" prooph/php:7.0-cli-xdebug php [your file]
+```
+
 ## cli with SensioLabs Blackfire
 Use the following image: `prooph/php:7.0-cli-blackfire`.
 
@@ -80,7 +86,7 @@ Use the following image: `prooph/php:7.0-fpm-blackfire`.
 
 [SensioLabs Blackfire](https://blackfire.io/) is a PHP Profiler.
 
-Please refer to the [docs](https://blackfire.io/docs/integrations/docker)to analyze your application. 
+Please refer to the [docs](https://blackfire.io/docs/integrations/docker)to analyze your application.
 You need the Blackfire Agent Docke image.
 
 ## fpm with Zend Z-Ray (only PHP 5.6)
@@ -93,5 +99,3 @@ Unfortunately the input fields are hidden (display:none). Open the browsers *dev
 Firebug and remove the `display:none` styles of the `devbar-settings` form.
 
 Then you have to restart the Docker containers.
-
-

--- a/php/config/xdebug-cli.ini
+++ b/php/config/xdebug-cli.ini
@@ -6,7 +6,7 @@ xdebug.remote_handler=dbgp
 xdebug.remote_port=9000
 xdebug.remote_autostart=1
 ; Dockers network IP, change it via PHP cli ini configuration option if needed
-xdebug.remote_host=172.17.0.1
+xdebug.remote_host=${XDEBUG_HOST}
 xdebug.remote_connect_back=1
 
 ; display config


### PR DESCRIPTION
According to this **[article](https://docs.docker.com/docker-for-mac/networking/#known-limitations-use-cases-and-workarounds)** mac users should use different hostname in xdebug. Setting it to `docker.for.mac.localhost` will resolve problems