### PR TITLE
Add protobuf extension

### DIFF
--- a/php/7.0-cli
+++ b/php/7.0-cli
@@ -5,6 +5,7 @@ ENV RABBITMQ_VERSION v0.8.0
 ENV PHP_AMQP_VERSION v1.9.3
 ENV PHP_REDIS_VERSION 4.1.0
 ENV PHP_MONGO_VERSION 1.5.2
+ENV PHP_PROTOBUF_VERSION v0.12.3
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
     autoconf \
@@ -90,6 +91,13 @@ RUN set -xe \
         && make  \
         && make install \
         && make test \
+    && git clone --branch ${PHP_PROTOBUF_VERSION} https://github.com/allegro/php-protobuf /tmp/phpprotobuf \
+        && cd /tmp/phpprotobuf \
+        && phpize  \
+        && ./configure  \
+        && make  \
+        && make install \
+        && make test \
     && apk del .build-deps \
     && rm -rf /tmp/* \
     && rm -rf /app \
@@ -99,6 +107,7 @@ COPY config/php7.ini /usr/local/etc/php/conf.d/
 COPY config/amqp.ini /usr/local/etc/php/conf.d/
 COPY config/redis.ini /usr/local/etc/php/conf.d/
 COPY config/mongodb.ini /usr/local/etc/php/conf.d/
+COPY config/protobuf.ini /usr/local/etc/php/conf.d/
 COPY config/php-cli.ini /usr/local/etc/php/php.ini
 # persistent / runtime deps
 ENV PHPIZE_DEPS \

--- a/php/7.0-fpm
+++ b/php/7.0-fpm
@@ -5,6 +5,7 @@ ENV RABBITMQ_VERSION v0.8.0
 ENV PHP_AMQP_VERSION v1.9.3
 ENV PHP_REDIS_VERSION 4.1.0
 ENV PHP_MONGO_VERSION 1.5.2
+ENV PHP_PROTOBUF_VERSION v0.12.3
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
     autoconf \
@@ -90,6 +91,13 @@ RUN set -xe \
         && make  \
         && make install \
         && make test \
+    && git clone --branch ${PHP_PROTOBUF_VERSION} https://github.com/allegro/php-protobuf /tmp/phpprotobuf \
+        && cd /tmp/phpprotobuf \
+        && phpize  \
+        && ./configure  \
+        && make  \
+        && make install \
+        && make test \
     && apk del .build-deps \
     && rm -rf /tmp/* \
     && rm -rf /app \
@@ -99,6 +107,7 @@ COPY config/php7.ini /usr/local/etc/php/conf.d/
 COPY config/amqp.ini /usr/local/etc/php/conf.d/
 COPY config/redis.ini /usr/local/etc/php/conf.d/
 COPY config/mongodb.ini /usr/local/etc/php/conf.d/
+COPY config/protobuf.ini /usr/local/etc/php/conf.d/
 # Possible values for ext-name:
 # bcmath bz2 calendar ctype curl dba dom enchant exif fileinfo filter ftp gd gettext gmp hash iconv imap interbase intl
 # json ldap mbstring mcrypt mssql mysql mysqli oci8 odbc opcache pcntl pdo pdo_dblib pdo_firebird pdo_mysql pdo_oci

--- a/php/7.0-zts
+++ b/php/7.0-zts
@@ -5,6 +5,7 @@ ENV RABBITMQ_VERSION v0.8.0
 ENV PHP_AMQP_VERSION v1.9.3
 ENV PHP_REDIS_VERSION 4.1.0
 ENV PHP_MONGO_VERSION 1.5.2
+ENV PHP_PROTOBUF_VERSION v0.12.3
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
     autoconf \
@@ -90,6 +91,13 @@ RUN set -xe \
         && make  \
         && make install \
         && make test \
+    && git clone --branch ${PHP_PROTOBUF_VERSION} https://github.com/allegro/php-protobuf /tmp/phpprotobuf \
+        && cd /tmp/phpprotobuf \
+        && phpize  \
+        && ./configure  \
+        && make  \
+        && make install \
+        && make test \
     && apk del .build-deps \
     && rm -rf /tmp/* \
     && rm -rf /app \
@@ -99,6 +107,7 @@ COPY config/php7.ini /usr/local/etc/php/conf.d/
 COPY config/amqp.ini /usr/local/etc/php/conf.d/
 COPY config/redis.ini /usr/local/etc/php/conf.d/
 COPY config/mongodb.ini /usr/local/etc/php/conf.d/
+COPY config/protobuf.ini /usr/local/etc/php/conf.d/
 ENV PHP_PTHREADS_VERSION master
 # persistent / runtime deps
 ENV PHPIZE_DEPS \

--- a/php/7.1-cli
+++ b/php/7.1-cli
@@ -5,6 +5,7 @@ ENV RABBITMQ_VERSION v0.8.0
 ENV PHP_AMQP_VERSION v1.9.3
 ENV PHP_REDIS_VERSION 4.1.0
 ENV PHP_MONGO_VERSION 1.5.2
+ENV PHP_PROTOBUF_VERSION v0.12.3
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
     autoconf \
@@ -90,6 +91,13 @@ RUN set -xe \
         && make  \
         && make install \
         && make test \
+    && git clone --branch ${PHP_PROTOBUF_VERSION} https://github.com/allegro/php-protobuf /tmp/phpprotobuf \
+        && cd /tmp/phpprotobuf \
+        && phpize  \
+        && ./configure  \
+        && make  \
+        && make install \
+        && make test \
     && apk del .build-deps \
     && rm -rf /tmp/* \
     && rm -rf /app \
@@ -99,6 +107,7 @@ COPY config/php7.ini /usr/local/etc/php/conf.d/
 COPY config/amqp.ini /usr/local/etc/php/conf.d/
 COPY config/redis.ini /usr/local/etc/php/conf.d/
 COPY config/mongodb.ini /usr/local/etc/php/conf.d/
+COPY config/protobuf.ini /usr/local/etc/php/conf.d/
 COPY config/php-cli.ini /usr/local/etc/php/php.ini
 # persistent / runtime deps
 ENV PHPIZE_DEPS \

--- a/php/7.1-fpm
+++ b/php/7.1-fpm
@@ -5,6 +5,7 @@ ENV RABBITMQ_VERSION v0.8.0
 ENV PHP_AMQP_VERSION v1.9.3
 ENV PHP_REDIS_VERSION 4.1.0
 ENV PHP_MONGO_VERSION 1.5.2
+ENV PHP_PROTOBUF_VERSION v0.12.3
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
     autoconf \
@@ -90,6 +91,13 @@ RUN set -xe \
         && make  \
         && make install \
         && make test \
+    && git clone --branch ${PHP_PROTOBUF_VERSION} https://github.com/allegro/php-protobuf /tmp/phpprotobuf \
+        && cd /tmp/phpprotobuf \
+        && phpize  \
+        && ./configure  \
+        && make  \
+        && make install \
+        && make test \
     && apk del .build-deps \
     && rm -rf /tmp/* \
     && rm -rf /app \
@@ -99,6 +107,7 @@ COPY config/php7.ini /usr/local/etc/php/conf.d/
 COPY config/amqp.ini /usr/local/etc/php/conf.d/
 COPY config/redis.ini /usr/local/etc/php/conf.d/
 COPY config/mongodb.ini /usr/local/etc/php/conf.d/
+COPY config/protobuf.ini /usr/local/etc/php/conf.d/
 # Possible values for ext-name:
 # bcmath bz2 calendar ctype curl dba dom enchant exif fileinfo filter ftp gd gettext gmp hash iconv imap interbase intl
 # json ldap mbstring mcrypt mssql mysql mysqli oci8 odbc opcache pcntl pdo pdo_dblib pdo_firebird pdo_mysql pdo_oci

--- a/php/7.1-zts
+++ b/php/7.1-zts
@@ -5,6 +5,7 @@ ENV RABBITMQ_VERSION v0.8.0
 ENV PHP_AMQP_VERSION v1.9.3
 ENV PHP_REDIS_VERSION 4.1.0
 ENV PHP_MONGO_VERSION 1.5.2
+ENV PHP_PROTOBUF_VERSION v0.12.3
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
     autoconf \
@@ -90,6 +91,13 @@ RUN set -xe \
         && make  \
         && make install \
         && make test \
+    && git clone --branch ${PHP_PROTOBUF_VERSION} https://github.com/allegro/php-protobuf /tmp/phpprotobuf \
+        && cd /tmp/phpprotobuf \
+        && phpize  \
+        && ./configure  \
+        && make  \
+        && make install \
+        && make test \
     && apk del .build-deps \
     && rm -rf /tmp/* \
     && rm -rf /app \
@@ -99,6 +107,7 @@ COPY config/php7.ini /usr/local/etc/php/conf.d/
 COPY config/amqp.ini /usr/local/etc/php/conf.d/
 COPY config/redis.ini /usr/local/etc/php/conf.d/
 COPY config/mongodb.ini /usr/local/etc/php/conf.d/
+COPY config/protobuf.ini /usr/local/etc/php/conf.d/
 ENV PHP_PTHREADS_VERSION master
 # persistent / runtime deps
 ENV PHPIZE_DEPS \

--- a/php/7.2-cli
+++ b/php/7.2-cli
@@ -5,6 +5,7 @@ ENV RABBITMQ_VERSION v0.8.0
 ENV PHP_AMQP_VERSION v1.9.3
 ENV PHP_REDIS_VERSION 4.1.0
 ENV PHP_MONGO_VERSION 1.5.2
+ENV PHP_PROTOBUF_VERSION v0.12.3
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
     autoconf \
@@ -90,6 +91,13 @@ RUN set -xe \
         && make  \
         && make install \
         && make test \
+    && git clone --branch ${PHP_PROTOBUF_VERSION} https://github.com/allegro/php-protobuf /tmp/phpprotobuf \
+        && cd /tmp/phpprotobuf \
+        && phpize  \
+        && ./configure  \
+        && make  \
+        && make install \
+        && make test \
     && apk del .build-deps \
     && rm -rf /tmp/* \
     && rm -rf /app \
@@ -99,6 +107,7 @@ COPY config/php7.ini /usr/local/etc/php/conf.d/
 COPY config/amqp.ini /usr/local/etc/php/conf.d/
 COPY config/redis.ini /usr/local/etc/php/conf.d/
 COPY config/mongodb.ini /usr/local/etc/php/conf.d/
+COPY config/protobuf.ini /usr/local/etc/php/conf.d/
 COPY config/php-cli.ini /usr/local/etc/php/php.ini
 # persistent / runtime deps
 ENV PHPIZE_DEPS \

--- a/php/7.2-fpm
+++ b/php/7.2-fpm
@@ -5,6 +5,7 @@ ENV RABBITMQ_VERSION v0.8.0
 ENV PHP_AMQP_VERSION v1.9.3
 ENV PHP_REDIS_VERSION 4.1.0
 ENV PHP_MONGO_VERSION 1.5.2
+ENV PHP_PROTOBUF_VERSION v0.12.3
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
     autoconf \
@@ -90,6 +91,13 @@ RUN set -xe \
         && make  \
         && make install \
         && make test \
+    && git clone --branch ${PHP_PROTOBUF_VERSION} https://github.com/allegro/php-protobuf /tmp/phpprotobuf \
+        && cd /tmp/phpprotobuf \
+        && phpize  \
+        && ./configure  \
+        && make  \
+        && make install \
+        && make test \
     && apk del .build-deps \
     && rm -rf /tmp/* \
     && rm -rf /app \
@@ -99,6 +107,7 @@ COPY config/php7.ini /usr/local/etc/php/conf.d/
 COPY config/amqp.ini /usr/local/etc/php/conf.d/
 COPY config/redis.ini /usr/local/etc/php/conf.d/
 COPY config/mongodb.ini /usr/local/etc/php/conf.d/
+COPY config/protobuf.ini /usr/local/etc/php/conf.d/
 # Possible values for ext-name:
 # bcmath bz2 calendar ctype curl dba dom enchant exif fileinfo filter ftp gd gettext gmp hash iconv imap interbase intl
 # json ldap mbstring mcrypt mssql mysql mysqli oci8 odbc opcache pcntl pdo pdo_dblib pdo_firebird pdo_mysql pdo_oci

--- a/php/7.2-zts
+++ b/php/7.2-zts
@@ -5,6 +5,7 @@ ENV RABBITMQ_VERSION v0.8.0
 ENV PHP_AMQP_VERSION v1.9.3
 ENV PHP_REDIS_VERSION 4.1.0
 ENV PHP_MONGO_VERSION 1.5.2
+ENV PHP_PROTOBUF_VERSION v0.12.3
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
     autoconf \
@@ -90,6 +91,13 @@ RUN set -xe \
         && make  \
         && make install \
         && make test \
+    && git clone --branch ${PHP_PROTOBUF_VERSION} https://github.com/allegro/php-protobuf /tmp/phpprotobuf \
+        && cd /tmp/phpprotobuf \
+        && phpize  \
+        && ./configure  \
+        && make  \
+        && make install \
+        && make test \
     && apk del .build-deps \
     && rm -rf /tmp/* \
     && rm -rf /app \
@@ -99,6 +107,7 @@ COPY config/php7.ini /usr/local/etc/php/conf.d/
 COPY config/amqp.ini /usr/local/etc/php/conf.d/
 COPY config/redis.ini /usr/local/etc/php/conf.d/
 COPY config/mongodb.ini /usr/local/etc/php/conf.d/
+COPY config/protobuf.ini /usr/local/etc/php/conf.d/
 ENV PHP_PTHREADS_VERSION master
 # persistent / runtime deps
 ENV PHPIZE_DEPS \

--- a/php/README.md
+++ b/php/README.md
@@ -16,11 +16,12 @@ Extends the official PHP image with the following PHP extensions:
 * amqp
 * redis
 * soap
-* swoole
+* protobuf (PHP 7.2 only)
+* swoole (cli only)
 
 See [prooph/proophessor-do app](https://github.com/prooph/proophessor-do) for an example.
 
-> Each image has tags for 7.2, 7.1 and 7.2
+> Each image has tags for 7.0, 7.1 and 7.2
 
 There are also PHP ZTS versions.
 
@@ -87,4 +88,4 @@ Use the following image: `prooph/php:7.2-fpm-blackfire`.
 [SensioLabs Blackfire](https://blackfire.io/) is a PHP Profiler.
 
 Please refer to the [docs](https://blackfire.io/docs/integrations/docker)to analyze your application.
-You need the Blackfire Agent Docke image.
+You need the Blackfire Agent Docker image.

--- a/php/config/protobuf.ini
+++ b/php/config/protobuf.ini
@@ -1,0 +1,1 @@
+extension=protobuf.so

--- a/php/inc/php-ext.m4
+++ b/php/inc/php-ext.m4
@@ -3,6 +3,7 @@ ENV RABBITMQ_VERSION v0.8.0
 ENV PHP_AMQP_VERSION v1.9.3
 ENV PHP_REDIS_VERSION 4.1.0
 ENV PHP_MONGO_VERSION 1.5.2
+ENV PHP_PROTOBUF_VERSION v0.12.3
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -91,6 +92,13 @@ RUN set -xe \
         && make  \
         && make install \
         && make test \
+    && git clone --branch ${PHP_PROTOBUF_VERSION} https://github.com/allegro/php-protobuf /tmp/phpprotobuf \
+        && cd /tmp/phpprotobuf \
+        && phpize  \
+        && ./configure  \
+        && make  \
+        && make install \
+        && make test \
     && apk del .build-deps \
     && rm -rf /tmp/* \
     && rm -rf /app \
@@ -101,3 +109,4 @@ COPY config/php7.ini /usr/local/etc/php/conf.d/
 COPY config/amqp.ini /usr/local/etc/php/conf.d/
 COPY config/redis.ini /usr/local/etc/php/conf.d/
 COPY config/mongodb.ini /usr/local/etc/php/conf.d/
+COPY config/protobuf.ini /usr/local/etc/php/conf.d/


### PR DESCRIPTION
The extension is required by our new [event-store-client](https://github.com/prooph/event-store-client#installation)