### PR TITLE
Fix wrong GeoIP URL's

### DIFF
--- a/nginx/www/Dockerfile
+++ b/nginx/www/Dockerfile
@@ -6,9 +6,9 @@ RUN set -xe \
         gzip
 
 RUN mkdir -p /etc/nginx/data \
-    && curl -sSL -D - -A "Docker" -o /tmp/GeoIP.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz \
+    && curl -sSL -D - -A "Docker" -o /tmp/GeoIP.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz \
     && gunzip -c /tmp/GeoIP.dat.gz > /etc/nginx/data/GeoIP.dat \
-    && curl -sSL -D - -A "Docker" -o /tmp/GeoLiteCity.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz \
+    && curl -sSL -D - -A "Docker" -o /tmp/GeoLiteCity.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
     && gunzip -c /tmp/GeoLiteCity.dat.gz > /etc/nginx/data/GeoLiteCity.dat \
     && apk del .build-deps
 


### PR DESCRIPTION
Hi,

I got an error using the nginx image, GeoIP files are no longer available.

```
Step 3/5 : RUN mkdir -p /etc/nginx/data     && curl -sSL -D - -A "Docker" -o /tmp/GeoIP.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz     && gunzip -c /tmp/GeoIP.dat.gz > /etc/nginx/data/GeoIP.dat     && curl -sSL -D - -A "Docker" -o /tmp/GeoLiteCity.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz     && gunzip -c /tmp/GeoLiteCity.dat.gz > /etc/nginx/data/GeoLiteCity.dat     && apk del .build-deps
 ---> Running in 480b82d9d1d1
HTTP/1.1 404 Not Found
Date: Fri, 26 Apr 2019 05:38:43 GMT
Content-Type: text/html
Transfer-Encoding: chunked
Connection: keep-alive
Set-Cookie: __cfduid=da412ff6b03dc86f3de647e72886b08a21556257123; expires=Sat, 25-Apr-20 05:38:43 GMT; path=/; domain=.geolite.maxmind.com; HttpOnly
CF-Cache-Status: HIT
Expires: Fri, 26 Apr 2019 09:38:43 GMT
Cache-Control: public, max-age=14400
Server: cloudflare
CF-RAY: 4cd6364b7f092f83-MAD


gzip: /tmp/GeoIP.dat.gz: not in gzip format
ERROR: Service 'nginx' failed to build: The command '/bin/sh -c mkdir -p /etc/nginx/data     && curl -sSL -D - -A "Docker" -o /tmp/GeoIP.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz     && gunzip -c /tmp/GeoIP.dat.gz > /etc/nginx/data/GeoIP.dat     && curl -sSL -D - -A "Docker" -o /tmp/GeoLiteCity.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz     && gunzip -c /tmp/GeoLiteCity.dat.gz > /etc/nginx/data/GeoLiteCity.dat     && apk del .build-deps' returned a non-zero code: 1
```

See [Discontinuation of the GeoLite Legacy Databases](https://blog.maxmind.com/2018/01/02/discontinuation-of-the-geolite-legacy-databases/)

So here I'm updating to a valid URL.

Thank you
