### PR TITLE
Update Nginx to version 1.17 (CVE-2019-9511, CVE-2019-9513, CVE-2019-9516)

### DIFF
--- a/nginx/www/Dockerfile
+++ b/nginx/www/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15.2-alpine
+FROM nginx:1.17-alpine
 
 RUN set -xe \
     && apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
Update Nginx to 1.17. Merge this when 1.17.3 is released as Docker image, to prevent recent discovered attacks over HTTP/2 protocol.

See here:
nginxinc/docker-nginx#358
and:
https://www.nginx.com/blog/nginx-updates-mitigate-august-2019-http-2-vulnerabilities/