### PR TITLE
Remove GeoIP module because it's not compatible with Maxmind v2 database

### DIFF
--- a/nginx/symfony/config/sites-enabled/www.conf
+++ b/nginx/symfony/config/sites-enabled/www.conf
@@ -15,8 +15,10 @@ server {
     }
 
     location ~ \.php$ {
+        set $upstream php:9000;
+
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass    php:9000;
+        fastcgi_pass    $upstream;
         fastcgi_index   index.php;
         fastcgi_param   SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include         fastcgi_params;

--- a/nginx/www/Dockerfile
+++ b/nginx/www/Dockerfile
@@ -1,17 +1,5 @@
 FROM nginx:1.17-alpine
 
-RUN set -xe \
-    && apk add --no-cache --virtual .build-deps \
-        curl \
-        gzip
-
-RUN mkdir -p /etc/nginx/data \
-    && curl -sSL -D - -A "Docker" -o /tmp/GeoIP.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz \
-    && gunzip -c /tmp/GeoIP.dat.gz > /etc/nginx/data/GeoIP.dat \
-    && curl -sSL -D - -A "Docker" -o /tmp/GeoLiteCity.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz \
-    && gunzip -c /tmp/GeoLiteCity.dat.gz > /etc/nginx/data/GeoLiteCity.dat \
-    && apk del .build-deps
-
 COPY config/ /etc/nginx/
 
 WORKDIR /var/www

--- a/nginx/www/config/fastcgi_params
+++ b/nginx/www/config/fastcgi_params
@@ -22,15 +22,3 @@ fastcgi_param   SERVER_PORT             $server_port;
 fastcgi_param   SERVER_NAME             $server_name;
 
 fastcgi_param   HTTPS                   $https;
-
-fastcgi_param  GEOIP_ADDR                $remote_addr;
-fastcgi_param  GEOIP_COUNTRY_CODE        $geoip_country_code;
-fastcgi_param  GEOIP_COUNTRY_NAME        $geoip_country_name;
-fastcgi_param  GEOIP_REGION              $geoip_region;
-fastcgi_param  GEOIP_REGION_NAME         $geoip_region_name;
-fastcgi_param  GEOIP_CITY                $geoip_city;
-fastcgi_param  GEOIP_AREA_CODE           $geoip_area_code;
-fastcgi_param  GEOIP_LATITUDE            $geoip_latitude;
-fastcgi_param  GEOIP_LONGITUDE           $geoip_longitude;
-fastcgi_param  GEOIP_POSTAL_CODE         $geoip_postal_code;
-fastcgi_param  GEOIP_CITY_CONTINENT_CODE $geoip_city_continent_code;

--- a/nginx/www/config/nginx.conf
+++ b/nginx/www/config/nginx.conf
@@ -1,8 +1,6 @@
 # nginx Configuration File
 # http://wiki.nginx.org/Configuration
 
-load_module "modules/ngx_http_geoip_module.so";
-
 # Run as a less privileged user for security reasons.
 user nginx;
 
@@ -32,11 +30,6 @@ error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
 
 http {
-  # GeoIP
-  geoip_country         /etc/nginx/data/GeoIP.dat;
-  geoip_city            /etc/nginx/data/GeoLiteCity.dat;
-  geoip_proxy_recursive on;
-
   # Hide nginx version information.
   server_tokens off;
 


### PR DESCRIPTION
If you need GeoIP supoprt, compile nginx with [ngx_http_geoip2_module](https://github.com/leev/ngx_http_geoip2_module).

Closes #40 